### PR TITLE
feat: set printer variables through gcode_macro

### DIFF
--- a/macro/variables.cfg
+++ b/macro/variables.cfg
@@ -1,3 +1,12 @@
+[gcode_macro PRINTER_VARS]
+variable_nozzle_size: 0.4
+variable_bed_temp: 100
+variable_chamber_temp: 0
+variable_extruder_temp: 240
+variable_extruder_temp_initial: 0
+variable_filter_speed: 0
+variable_filament_type: 
+
 [gcode_macro SEARCH_VARS]
 gcode:
   {% set search = params.S|lower %}


### PR DESCRIPTION
Centralize shared variables nstead of passing them between macros